### PR TITLE
Add licensing and attribution summary

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,0 +1,37 @@
+# Third-Party Licenses and Attributions
+
+## Iconography
+
+### Tabler Icons (via Lucide CDN)
+- **License:** MIT License — https://tabler-icons.io/license (mirrored in the Lucide distribution: https://github.com/lucide-icons/lucide/blob/main/LICENSE)
+- **Usage:** Icons are injected at runtime by the Lucide CDN script referenced in `index.html`.
+- **Icon filenames referenced in the markup:**
+  - `arrow-right.svg`
+  - `blocks.svg`
+  - `box.svg`
+  - `check-circle-2.svg`
+  - `chevron-left.svg`
+  - `chevron-right.svg`
+  - `cpu.svg`
+  - `graduation-cap.svg`
+  - `mail.svg`
+  - `map-pin.svg`
+  - `panel-right-open.svg`
+  - `phone.svg`
+  - `printer.svg`
+  - `scan.svg`
+  - `send.svg`
+  - `shield.svg`
+  - `sparkles.svg`
+  - `x.svg`
+
+> **Note:** Lucide is an MIT-licensed fork compatible with Tabler icon filenames. If the project switches to a direct Tabler Icons build, the filename mapping above remains valid.
+
+## Logos and Wordmarks
+- No standalone logo assets are stored in the repository. All partner/product references (Perplexity AI, Qwen AI, Blender, FreeCAD, OpenSCAD, Hugging Face, T-FLEX CAD, NotebookLM) are currently text-only links without embedded graphics.
+- The NotebookLM entry is a temporary text placeholder until Google releases official embeddable assets for public use.
+- When vendor or Wikimedia-hosted logo files are added, record their direct source URLs and licensing terms (e.g., specific CC BY version or vendor kit EULA) here before publication.
+
+## Photography and Other Media
+- Local gallery images in `images/lab/1.jpg`–`6.jpg` are supplied as internal placeholders. Replace them with owned or appropriately licensed imagery before release.
+- No externally downloaded media with attribution requirements (e.g., CC BY) are bundled at this time.


### PR DESCRIPTION
## Summary
- add a LICENSES.md file summarizing icon licensing and other third-party attribution notes
- document the Tabler/Lucide icon filenames used across the markup
- clarify current logo placeholders and guidance for future media sources

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d969b6d1e48333907c046de82ecbe3