### PR TITLE
Replace Lucide icons with inline Tabler assets

### DIFF
--- a/assets/icons/tabler/icon-arrow-right.svg
+++ b/assets/icons/tabler/icon-arrow-right.svg
@@ -1,0 +1,21 @@
+<!--
+tags: [next, proceed, swipe]
+category: Arrows
+version: "1.0"
+unicode: "ea1f"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12l14 0" />
+  <path d="M13 18l6 -6" />
+  <path d="M13 6l6 6" />
+</svg>

--- a/assets/icons/tabler/icon-blocks.svg
+++ b/assets/icons/tabler/icon-blocks.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [structure, stack, build, cube, brick, construct, arrange, assemble, piece, model]
+unicode: "100b2"
+version: "3.23"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 4a1 1 0 0 1 1 -1h5a1 1 0 0 1 1 1v5a1 1 0 0 1 -1 1h-5a1 1 0 0 1 -1 -1z" />
+  <path d="M3 14h12a2 2 0 0 1 2 2v3a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h3a2 2 0 0 1 2 2v12" />
+</svg>

--- a/assets/icons/tabler/icon-box.svg
+++ b/assets/icons/tabler/icon-box.svg
@@ -1,0 +1,21 @@
+<!--
+tags: [cube, app, application, package, container]
+version: "1.0"
+unicode: "ea45"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3l8 4.5l0 9l-8 4.5l-8 -4.5l0 -9l8 -4.5" />
+  <path d="M12 12l8 -4.5" />
+  <path d="M12 12l0 9" />
+  <path d="M12 12l-8 -4.5" />
+</svg>

--- a/assets/icons/tabler/icon-chevron-left.svg
+++ b/assets/icons/tabler/icon-chevron-left.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [move, previous, back]
+category: Arrows
+version: "1.0"
+unicode: "ea60"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 6l-6 6l6 6" />
+</svg>

--- a/assets/icons/tabler/icon-chevron-right.svg
+++ b/assets/icons/tabler/icon-chevron-right.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [move, checklist, next]
+category: Arrows
+version: "1.0"
+unicode: "ea61"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 6l6 6l-6 6" />
+</svg>

--- a/assets/icons/tabler/icon-circle-check.svg
+++ b/assets/icons/tabler/icon-circle-check.svg
@@ -1,0 +1,20 @@
+<!--
+category: Shapes
+tags: [accept, yes, tick, done]
+version: "1.0"
+unicode: "ea67"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+  <path d="M9 12l2 2l4 -4" />
+</svg>

--- a/assets/icons/tabler/icon-cpu.svg
+++ b/assets/icons/tabler/icon-cpu.svg
@@ -1,0 +1,28 @@
+<!--
+tags: [processor, computer, chip, hardware, technology, electronic]
+category: Devices
+version: "1.47"
+unicode: "ef8e"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5m0 1a1 1 0 0 1 1 -1h12a1 1 0 0 1 1 1v12a1 1 0 0 1 -1 1h-12a1 1 0 0 1 -1 -1z" />
+  <path d="M9 9h6v6h-6z" />
+  <path d="M3 10h2" />
+  <path d="M3 14h2" />
+  <path d="M10 3v2" />
+  <path d="M14 3v2" />
+  <path d="M21 10h-2" />
+  <path d="M21 14h-2" />
+  <path d="M14 21v-2" />
+  <path d="M10 21v-2" />
+</svg>

--- a/assets/icons/tabler/icon-layout-sidebar-right-expand.svg
+++ b/assets/icons/tabler/icon-layout-sidebar-right-expand.svg
@@ -1,0 +1,21 @@
+<!--
+tags: [grid, aside, column, columns, menu, navigation]
+version: "1.53"
+category: Design
+unicode: "f007"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
+  <path d="M15 4v16" />
+  <path d="M10 10l-2 2l2 2" />
+</svg>

--- a/assets/icons/tabler/icon-mail.svg
+++ b/assets/icons/tabler/icon-mail.svg
@@ -1,0 +1,20 @@
+<!--
+category: Communication
+tags: [inbox, gmail, email, envelope, message]
+version: "1.0"
+unicode: "eae5"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />
+  <path d="M3 7l9 6l9 -6" />
+</svg>

--- a/assets/icons/tabler/icon-map-pin.svg
+++ b/assets/icons/tabler/icon-map-pin.svg
@@ -1,0 +1,20 @@
+<!--
+category: Map
+tags: [navigation, location, travel, pin, position, marker]
+version: "1.0"
+unicode: "eae8"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
+  <path d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z" />
+</svg>

--- a/assets/icons/tabler/icon-phone.svg
+++ b/assets/icons/tabler/icon-phone.svg
@@ -1,0 +1,19 @@
+<!--
+category: Devices
+tags: [call, mobile, conversation, landline, answer, number]
+version: "1.0"
+unicode: "eb09"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 4h4l2 5l-2.5 1.5a11 11 0 0 0 5 5l1.5 -2.5l5 2v4a2 2 0 0 1 -2 2a16 16 0 0 1 -15 -15a2 2 0 0 1 2 -2" />
+</svg>

--- a/assets/icons/tabler/icon-printer.svg
+++ b/assets/icons/tabler/icon-printer.svg
@@ -1,0 +1,21 @@
+<!--
+category: Devices
+tags: [fax, office, device]
+version: "1.0"
+unicode: "eb0e"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" />
+  <path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" />
+  <path d="M7 13m0 2a2 2 0 0 1 2 -2h6a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-6a2 2 0 0 1 -2 -2z" />
+</svg>

--- a/assets/icons/tabler/icon-scan.svg
+++ b/assets/icons/tabler/icon-scan.svg
@@ -1,0 +1,23 @@
+<!--
+category: System
+tags: [code, barcode, qr code, app, scanner, document]
+version: "1.5"
+unicode: "ebc8"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 7v-1a2 2 0 0 1 2 -2h2" />
+  <path d="M4 17v1a2 2 0 0 0 2 2h2" />
+  <path d="M16 4h2a2 2 0 0 1 2 2v1" />
+  <path d="M16 20h2a2 2 0 0 0 2 -2v-1" />
+  <path d="M5 12l14 0" />
+</svg>

--- a/assets/icons/tabler/icon-school.svg
+++ b/assets/icons/tabler/icon-school.svg
@@ -1,0 +1,20 @@
+<!--
+category: Map
+tags: [students, class, teachers, professors, doctors, hall, classroom, subject, science, break, lesson]
+version: "1.22"
+unicode: "ecf7"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+  <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+</svg>

--- a/assets/icons/tabler/icon-send.svg
+++ b/assets/icons/tabler/icon-send.svg
@@ -1,0 +1,20 @@
+<!--
+category: Communication
+tags: [message, mail, email, gmail, paper, airplane, aeroplane]
+version: "1.0"
+unicode: "eb1e"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 14l11 -11" />
+  <path d="M21 3l-6.5 18a.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a.55 .55 0 0 1 0 -1l18 -6.5" />
+</svg>

--- a/assets/icons/tabler/icon-shield.svg
+++ b/assets/icons/tabler/icon-shield.svg
@@ -1,0 +1,19 @@
+<!--
+category: System
+tags: [safety, protect, protection]
+version: "1.0"
+unicode: "eb24"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" />
+</svg>

--- a/assets/icons/tabler/icon-sparkles.svg
+++ b/assets/icons/tabler/icon-sparkles.svg
@@ -1,0 +1,18 @@
+<!--
+tags: [star, light, fire, shine]
+version: "2.1"
+unicode: "f6d7"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+</svg>

--- a/assets/icons/tabler/icon-x.svg
+++ b/assets/icons/tabler/icon-x.svg
@@ -1,0 +1,19 @@
+<!--
+tags: [cancel, remove, delete, empty, close]
+version: "1.0"
+unicode: "eb55"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6l-12 12" />
+  <path d="M6 6l12 12" />
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,18 +3,12 @@
 
 // Ждём полной загрузки DOM (скрипт подключён с defer, но на всякий случай)
 document.addEventListener('DOMContentLoaded', () => {
-  initIcons();
   setYear();
   initMobileMenu();
   initRevealOnScroll();
   initEquipmentFilter();
   initGalleryLightbox();
 });
-
-// Инициализация набора иконок Lucide
-function initIcons() {
-  if (window.lucide && lucide.createIcons) lucide.createIcons();
-}
 
 // Подстановка текущего года в футере
 function setYear() {

--- a/index.html
+++ b/index.html
@@ -22,9 +22,14 @@
 
   <!-- Небольшие пользовательские стили (компонентные классы) -->
   <link rel="stylesheet" href="assets/css/custom.css" />
+  <link rel="stylesheet" href="styles/icons.css" />
 
-  <!-- Иконки Lucide (ванильная версия) -->
-  <script src="https://unpkg.com/lucide@latest" defer></script>
+  <link rel="preload" href="assets/icons/tabler/icon-blocks.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="assets/icons/tabler/icon-arrow-right.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="assets/icons/tabler/icon-layout-sidebar-right-expand.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="assets/icons/tabler/icon-sparkles.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="assets/icons/tabler/icon-shield.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="assets/icons/tabler/icon-school.svg" as="image" type="image/svg+xml" />
 
   <!-- Основной JS проекта -->
   <script src="assets/js/main.js" defer></script>
@@ -45,7 +50,23 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
       <a href="#top" class="flex items-center gap-2 font-semibold tracking-tight">
         <div class="h-8 w-8 rounded-xl bg-gradient-to-br from-indigo-500 via-blue-500 to-teal-400 grid place-items-center shadow-sm">
-          <i data-lucide="blocks" class="h-5 w-5 text-white"></i>
+          <span class="icon h-5 w-5 text-white" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Эмблема Step3D.Lab</title>
+              <path d="M14 4a1 1 0 0 1 1 -1h5a1 1 0 0 1 1 1v5a1 1 0 0 1 -1 1h-5a1 1 0 0 1 -1 -1z" />
+              <path d="M3 14h12a2 2 0 0 1 2 2v3a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h3a2 2 0 0 1 2 2v12" />
+            </svg>
+          </span>
         </div>
         <span class="text-lg">Step3D.Lab</span>
       </a>
@@ -59,12 +80,46 @@
         <a href="#faq" class="hover:text-indigo-600">FAQ</a>
         <a href="#contact" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-white hover:bg-slate-800">
           Оставить заявку
-          <i data-lucide="arrow-right" class="h-4 w-4"></i>
+          <span class="icon h-4 w-4" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Перейти</title>
+              <path d="M5 12l14 0" />
+              <path d="M13 18l6 -6" />
+              <path d="M13 6l6 6" />
+            </svg>
+          </span>
         </a>
       </nav>
       <div class="md:hidden">
         <button id="menuBtn" aria-label="Открыть меню" class="p-2 rounded-xl border border-slate-200">
-          <i data-lucide="panel-right-open" class="h-5 w-5"></i>
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Открыть меню</title>
+              <path d="M4 4m0 2a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-12a2 2 0 0 1 -2 -2z" />
+              <path d="M15 4v16" />
+              <path d="M10 10l-2 2l2 2" />
+            </svg>
+          </span>
         </button>
       </div>
     </div>
@@ -95,7 +150,24 @@
         <div class="mt-8 flex flex-wrap items-center gap-3">
           <a href="#contact" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white hover:bg-slate-800">
             Оставить заявку
-            <i data-lucide="arrow-right" class="h-4 w-4"></i>
+            <span class="icon h-4 w-4" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>Перейти</title>
+                <path d="M5 12l14 0" />
+                <path d="M13 18l6 -6" />
+                <path d="M13 6l6 6" />
+              </svg>
+            </span>
           </a>
           <a href="#features" class="inline-flex items-center gap-2 rounded-xl border border-slate-300 px-5 py-3 hover:border-slate-900">
             О лаборатории
@@ -107,7 +179,22 @@
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
               <div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
-                <i data-lucide="sparkles" class="h-5 w-5"></i>
+                <span class="icon h-5 w-5" aria-hidden="true">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <title>Преимущество</title>
+                    <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+                  </svg>
+                </span>
               </div>
               <h3 class="font-semibold">Полный цикл</h3>
             </div>
@@ -116,7 +203,22 @@
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
               <div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
-                <i data-lucide="shield" class="h-5 w-5"></i>
+                <span class="icon h-5 w-5" aria-hidden="true">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <title>Надёжность</title>
+                    <path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" />
+                  </svg>
+                </span>
               </div>
               <h3 class="font-semibold">Проектная работа</h3>
             </div>
@@ -125,7 +227,23 @@
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
               <div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
-                <i data-lucide="graduation-cap" class="h-5 w-5"></i>
+                <span class="icon h-5 w-5" aria-hidden="true">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <title>Обучение</title>
+                    <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+                    <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+                  </svg>
+                </span>
               </div>
               <h3 class="font-semibold">Курсы ДПО</h3>
             </div>
@@ -142,32 +260,153 @@
         <p class="mt-2 text-slate-600 max-w-2xl">Полный цикл — от скана и CAD до печати и презентации. Параллельно обучаем и сопровождаем проекты.</p>
         <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="scan" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>3D-сканирование</title>
+                <path d="M4 7v-1a2 2 0 0 1 2 -2h2" />
+                <path d="M4 17v1a2 2 0 0 0 2 2h2" />
+                <path d="M16 4h2a2 2 0 0 1 2 2v1" />
+                <path d="M16 20h2a2 2 0 0 0 2 -2v-1" />
+                <path d="M5 12l14 0" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">3D‑сканирование</h3>
             <p class="mt-2 text-slate-600 text-sm">Съём, обработка облаков/мешей, выверка и контроль.</p>
           </div>
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="cpu" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>CAD/CAE</title>
+                <path d="M5 5m0 1a1 1 0 0 1 1 -1h12a1 1 0 0 1 1 1v12a1 1 0 0 1 -1 1h-12a1 1 0 0 1 -1 -1z" />
+                <path d="M9 9h6v6h-6z" />
+                <path d="M3 10h2" />
+                <path d="M3 14h2" />
+                <path d="M10 3v2" />
+                <path d="M14 3v2" />
+                <path d="M21 10h-2" />
+                <path d="M21 14h-2" />
+                <path d="M14 21v-2" />
+                <path d="M10 21v-2" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">CAD/CAE‑моделирование</h3>
             <p class="mt-2 text-slate-600 text-sm">Parametric CAD, симуляции, подготовка техдоков.</p>
           </div>
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="shield" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>Надёжность</title>
+                <path d="M12 3a12 12 0 0 0 8.5 3a12 12 0 0 1 -8.5 15a12 12 0 0 1 -8.5 -15a12 12 0 0 0 8.5 -3" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">Реверсивный инжиниринг</h3>
             <p class="mt-2 text-slate-600 text-sm">Переход «Mesh→Solid», совместимость STEP/IGES.</p>
           </div>
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="printer" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>3D-печать</title>
+                <path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" />
+                <path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" />
+                <path d="M7 13m0 2a2 2 0 0 1 2 -2h6a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-6a2 2 0 0 1 -2 -2z" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">Аддитивное производство</h3>
             <p class="mt-2 text-slate-600 text-sm">FDM и DLP/SLA, пилотные партии, постпроцессинг.</p>
           </div>
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="box" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>Прототипирование</title>
+                <path d="M12 3l8 4.5l0 9l-8 4.5l-8 -4.5l0 -9l8 -4.5" />
+                <path d="M12 12l8 -4.5" />
+                <path d="M12 12l0 9" />
+                <path d="M12 12l-8 -4.5" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">Прототипирование</h3>
             <p class="mt-2 text-slate-600 text-sm">Сборка макетов, посадки и подгонка, презентация.</p>
           </div>
           <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="graduation-cap" class="h-5 w-5"></i></div>
+            <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+            <span class="icon h-5 w-5" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <title>Обучение</title>
+                <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+                <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+              </svg>
+            </span>
+            </div>
             <h3 class="mt-4 font-semibold">Образование</h3>
             <p class="mt-2 text-slate-600 text-sm">Курсы ДПО 48–72 ч, проектные школы, наставничество.</p>
           </div>
@@ -193,49 +432,221 @@
         <div id="equip-grid" class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <div data-type="scanners" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="scan" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-сканирование</title>
+                  <path d="M4 7v-1a2 2 0 0 1 2 -2h2" />
+                  <path d="M4 17v1a2 2 0 0 0 2 2h2" />
+                  <path d="M16 4h2a2 2 0 0 1 2 2v1" />
+                  <path d="M16 20h2a2 2 0 0 0 2 -2v-1" />
+                  <path d="M5 12l14 0" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">RangeVision NEO</div><div class="text-sm text-slate-500">RangeVision</div></div>
             </div>
           </div>
           <div data-type="scanners" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="scan" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-сканирование</title>
+                  <path d="M4 7v-1a2 2 0 0 1 2 -2h2" />
+                  <path d="M4 17v1a2 2 0 0 0 2 2h2" />
+                  <path d="M16 4h2a2 2 0 0 1 2 2v1" />
+                  <path d="M16 20h2a2 2 0 0 0 2 -2v-1" />
+                  <path d="M5 12l14 0" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">RangeVision Spectrum</div><div class="text-sm text-slate-500">RangeVision</div></div>
             </div>
           </div>
           <div data-type="scanners" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="scan" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-сканирование</title>
+                  <path d="M4 7v-1a2 2 0 0 1 2 -2h2" />
+                  <path d="M4 17v1a2 2 0 0 0 2 2h2" />
+                  <path d="M16 4h2a2 2 0 0 1 2 2v1" />
+                  <path d="M16 20h2a2 2 0 0 0 2 -2v-1" />
+                  <path d="M5 12l14 0" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Artec Eva</div><div class="text-sm text-slate-500">Artec · ручной</div></div>
             </div>
           </div>
           <div data-type="printers" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="printer" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-печать</title>
+                  <path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" />
+                  <path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" />
+                  <path d="M7 13m0 2a2 2 0 0 1 2 -2h6a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-6a2 2 0 0 1 -2 -2z" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Ultimaker 3</div><div class="text-sm text-slate-500">Ultimaker · FDM</div></div>
             </div>
           </div>
           <div data-type="printers" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="printer" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-печать</title>
+                  <path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" />
+                  <path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" />
+                  <path d="M7 13m0 2a2 2 0 0 1 2 -2h6a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-6a2 2 0 0 1 -2 -2z" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Designer X</div><div class="text-sm text-slate-500">Picaso 3D · FDM</div></div>
             </div>
           </div>
           <div data-type="printers" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="printer" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>3D-печать</title>
+                  <path d="M17 17h2a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-14a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h2" />
+                  <path d="M17 9v-4a2 2 0 0 0 -2 -2h-6a2 2 0 0 0 -2 2v4" />
+                  <path d="M7 13m0 2a2 2 0 0 1 2 -2h6a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-6a2 2 0 0 1 -2 -2z" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Formlabs (семейство)</div><div class="text-sm text-slate-500">Formlabs · DLP/SLA</div></div>
             </div>
           </div>
           <div data-type="cnc" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="cpu" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>CAD/CAE</title>
+                  <path d="M5 5m0 1a1 1 0 0 1 1 -1h12a1 1 0 0 1 1 1v12a1 1 0 0 1 -1 1h-12a1 1 0 0 1 -1 -1z" />
+                  <path d="M9 9h6v6h-6z" />
+                  <path d="M3 10h2" />
+                  <path d="M3 14h2" />
+                  <path d="M10 3v2" />
+                  <path d="M14 3v2" />
+                  <path d="M21 10h-2" />
+                  <path d="M21 14h-2" />
+                  <path d="M14 21v-2" />
+                  <path d="M10 21v-2" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Roland MDX‑40/50/540</div><div class="text-sm text-slate-500">CNC</div></div>
             </div>
           </div>
           <div data-type="cnc" class="equip-card rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
             <div class="flex items-center gap-3">
-              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="cpu" class="h-5 w-5"></i></div>
+              <div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+              <span class="icon h-5 w-5" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>CAD/CAE</title>
+                  <path d="M5 5m0 1a1 1 0 0 1 1 -1h12a1 1 0 0 1 1 1v12a1 1 0 0 1 -1 1h-12a1 1 0 0 1 -1 -1z" />
+                  <path d="M9 9h6v6h-6z" />
+                  <path d="M3 10h2" />
+                  <path d="M3 14h2" />
+                  <path d="M10 3v2" />
+                  <path d="M14 3v2" />
+                  <path d="M21 10h-2" />
+                  <path d="M21 14h-2" />
+                  <path d="M14 21v-2" />
+                  <path d="M10 21v-2" />
+                </svg>
+              </span>
+              </div>
               <div><div class="font-semibold">Trotec Speedy 300</div><div class="text-sm text-slate-500">Лазер</div></div>
             </div>
           </div>
@@ -289,10 +700,78 @@
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">Проекты и направления НИР</h2>
         <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center"><i data-lucide="sparkles" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">MedTech</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center"><i data-lucide="sparkles" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">Robotics</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center"><i data-lucide="sparkles" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">Reverse engineering</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center"><i data-lucide="sparkles" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">Design & Render</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Преимущество</title>
+              <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">MedTech</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Преимущество</title>
+              <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">Robotics</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Преимущество</title>
+              <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">Reverse engineering</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-indigo-600 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Преимущество</title>
+              <path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm0 -12a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2zm-7 12a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">Design & Render</div><p class="mt-1 text-sm text-slate-600">Исследования, пилоты и внедрения в партнёрстве с индустрией.</p></div>
         </div>
       </div>
 
@@ -300,9 +779,171 @@
         <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">Курсы ДПО и проектные школы</h2>
         <p class="mt-2 max-w-3xl text-сlate-600">Учебные планы 48–72 часа с индивидуальными проектами, подготовка к чемпионатам «Профессионалы», WorldSkills, HI‑TECH.</p>
         <div class="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-6">
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="graduation-cap" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">CAD/CAE‑моделирование</div><p class="mt-1 text-sm text-slate-600">Проект‑ориентированный трек</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>48–72 акад. часа</li><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>Индивидуальные проекты</li></ul></div>
-          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="graduation-cap" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">Реверсивный инжиниринг</div><p class="mt-1 text-sm text-slate-600">Scan→CAD, контроль качества</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>48–72 акад. часа</li><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>Индивидуальные проекты</li></ul></div>
-          <div class="reveal rounded-3xl border border-slate-200 bg-white п-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center"><i data-lucide="graduation-cap" class="h-5 w-5"></i></div><div class="mt-3 font-semibold">Аддитивное производство</div><p class="mt-1 text-sm text-slate-600">Материалы, режимы, постпроцесс</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>48–72 акад. часа</li><li class="flex items-center gap-2"><i data-lucide="check-circle-2" class="h-4 w-4 text-green-600"></i>Индивидуальные проекты</li></ul></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Обучение</title>
+              <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+              <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">CAD/CAE‑моделирование</div><p class="mt-1 text-sm text-slate-600">Проект‑ориентированный трек</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          48–72 акад. часа</li><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          Индивидуальные проекты</li></ul></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Обучение</title>
+              <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+              <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">Реверсивный инжиниринг</div><p class="mt-1 text-sm text-slate-600">Scan→CAD, контроль качества</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          48–72 акад. часа</li><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          Индивидуальные проекты</li></ul></div>
+          <div class="reveal rounded-3xl border border-slate-200 bg-white п-6 shadow-sm"><div class="h-10 w-10 rounded-2xl bg-slate-900 text-white grid place-items-center">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Обучение</title>
+              <path d="M22 9l-10 -4l-10 4l10 4l10 -4v6" />
+              <path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4" />
+            </svg>
+          </span>
+          </div><div class="mt-3 font-semibold">Аддитивное производство</div><p class="mt-1 text-sm text-slate-600">Материалы, режимы, постпроцесс</p><ul class="mt-3 space-y-1 text-sm text-slate-600"><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          48–72 акад. часа</li><li class="flex items-center gap-2">
+          <span class="icon h-4 w-4 text-green-600" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Подтверждено</title>
+              <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+              <path d="M9 12l2 2l4 -4" />
+            </svg>
+          </span>
+          Индивидуальные проекты</li></ul></div>
         </div>
       </div>
     </section>
@@ -331,9 +972,61 @@
       <!-- Лайтбокс (управление: стрелки/свайпы/клавиатура) -->
       <div id="lightbox" class="hidden fixed inset-0 z-50 grid place-items-center bg-black/70 p-4">
         <div class="relative w-full max-w-6xl">
-          <button id="lb-close" aria-label="Закрыть" class="absolute -top-10 right-0 rounded-full bg-white/90 p-2 shadow"><i data-lucide="x" class="h-5 w-5"></i></button>
-          <button id="lb-prev" aria-label="Предыдущее" class="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow hidden sm:flex"><i data-lucide="chevron-left" class="h-6 w-6"></i></button>
-          <button id="lb-next" aria-label="Следующее" class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow hidden sm:flex"><i data-lucide="chevron-right" class="h-6 w-6"></i></button>
+          <button id="lb-close" aria-label="Закрыть" class="absolute -top-10 right-0 rounded-full bg-white/90 p-2 shadow">
+          <span class="icon h-5 w-5" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Закрыть</title>
+              <path d="M18 6l-12 12" />
+              <path d="M6 6l12 12" />
+            </svg>
+          </span>
+          </button>
+          <button id="lb-prev" aria-label="Предыдущее" class="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow hidden sm:flex">
+          <span class="icon h-6 w-6" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Назад</title>
+              <path d="M15 6l-6 6l6 6" />
+            </svg>
+          </span>
+          </button>
+          <button id="lb-next" aria-label="Следующее" class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 shadow hidden sm:flex">
+          <span class="icon h-6 w-6" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Вперёд</title>
+              <path d="M9 6l6 6l-6 6" />
+            </svg>
+          </span>
+          </button>
           <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white">
             <div class="bg-black"><img id="lb-img" alt="" class="mx-auto max-h-[70vh] w-auto object-contain" /></div>
             <div id="lb-cap" class="border-t border-slate-200 p-3 text-sm text-slate-700"></div>
@@ -348,9 +1041,66 @@
       <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold tracking-tight text-center">Вопросы и ответы</h2>
         <div class="mt-8 space-y-4">
-          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">С кем вы работаете?<i data-lucide="arrow-right" class="h-4 w-4 transition-transform group-open:rotate-90"></i></summary><p class="mt-3 text-slate-600">С образовательными организациями, инженерными командами и частными заказчиками.</p></details>
-          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">Можно ли сделать пилотный проект?<i data-lucide="arrow-right" class="h-4 w-4 transition-transform group-open:rotate-90"></i></summary><p class="mt-3 text-slate-600">Да. Заполните заявку — предложим формат: учебный модуль, проект, НИОКР или услуга.</p></details>
-          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">Какие форматы обучения?<i data-lucide="arrow-right" class="h-4 w-4 transition-transform group-open:rotate-90"></i></summary><p class="mt-3 text-slate-600">Курсы ДПО 48–72 часа, проектные школы и наставничество над R&D‑задачами.</p></details>
+          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">С кем вы работаете?
+          <span class="icon h-4 w-4 transition-transform group-open:rotate-90" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Перейти</title>
+              <path d="M5 12l14 0" />
+              <path d="M13 18l6 -6" />
+              <path d="M13 6l6 6" />
+            </svg>
+          </span>
+          </summary><p class="mt-3 text-slate-600">С образовательными организациями, инженерными командами и частными заказчиками.</p></details>
+          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">Можно ли сделать пилотный проект?
+          <span class="icon h-4 w-4 transition-transform group-open:rotate-90" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Перейти</title>
+              <path d="M5 12l14 0" />
+              <path d="M13 18l6 -6" />
+              <path d="M13 6l6 6" />
+            </svg>
+          </span>
+          </summary><p class="mt-3 text-slate-600">Да. Заполните заявку — предложим формат: учебный модуль, проект, НИОКР или услуга.</p></details>
+          <details class="group rounded-2xl border border-slate-200 bg-white p-5 open:shadow-sm"><summary class="flex cursor-pointer list-none items-center justify-between font-medium">Какие форматы обучения?
+          <span class="icon h-4 w-4 transition-transform group-open:rotate-90" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Перейти</title>
+              <path d="M5 12l14 0" />
+              <path d="M13 18l6 -6" />
+              <path d="M13 6l6 6" />
+            </svg>
+          </span>
+          </summary><p class="mt-3 text-slate-600">Курсы ДПО 48–72 часа, проектные школы и наставничество над R&D‑задачами.</p></details>
         </div>
       </div>
     </section>
@@ -363,9 +1113,62 @@
             <h3 class="font-semibold text-lg">Контакты</h3>
             <p class="mt-2 text-slate-600">Задайте вопрос или оставьте заявку — поможем выбрать формат: учебный модуль, проект, НИОКР или услуга.</p>
             <div class="mt-4 space-y-3 text-sm">
-              <div class="flex items-center gap-2"><i data-lucide="map-pin" class="h-4 w-4"></i> Москва, ул. Беговая, 12</div>
-              <div class="flex items-center gap-2"><i data-lucide="phone" class="h-4 w-4"></i> +7 (000) 000‑00‑00</div>
-              <div class="flex items-center gap-2"><i data-lucide="mail" class="h-4 w-4"></i> info@step3d.lab</div>
+              <div class="flex items-center gap-2">
+              <span class="icon h-4 w-4" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>Адрес</title>
+                  <path d="M9 11a3 3 0 1 0 6 0a3 3 0 0 0 -6 0" />
+                  <path d="M17.657 16.657l-4.243 4.243a2 2 0 0 1 -2.827 0l-4.244 -4.243a8 8 0 1 1 11.314 0z" />
+                </svg>
+              </span>
+               Москва, ул. Беговая, 12</div>
+              <div class="flex items-center gap-2">
+              <span class="icon h-4 w-4" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>Телефон</title>
+                  <path d="M5 4h4l2 5l-2.5 1.5a11 11 0 0 0 5 5l1.5 -2.5l5 2v4a2 2 0 0 1 -2 2a16 16 0 0 1 -15 -15a2 2 0 0 1 2 -2" />
+                </svg>
+              </span>
+               +7 (000) 000‑00‑00</div>
+              <div class="flex items-center gap-2">
+              <span class="icon h-4 w-4" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>Email</title>
+                  <path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" />
+                  <path d="M3 7l9 6l9 -6" />
+                </svg>
+              </span>
+               info@step3d.lab</div>
             </div>
           </div>
 
@@ -379,7 +1182,25 @@
               <label class="sm:col-span-2 flex items-start gap-2 text-sm text-slate-600"><input type="checkbox" required class="mt-1"> Согласен(а) на обработку персональных данных</label>
             </div>
             <div class="mt-4 flex items-center gap-3">
-              <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white hover:bg-slate-800">Отправить <i data-lucide="send" class="h-4 w-4"></i></button>
+              <button type="submit" class="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-white hover:bg-slate-800">Отправить 
+              <span class="icon h-4 w-4" aria-hidden="true">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <title>Отправить</title>
+                  <path d="M10 14l11 -11" />
+                  <path d="M21 3l-6.5 18a.55 .55 0 0 1 -1 0l-3.5 -7l-7 -3.5a.55 .55 0 0 1 0 -1l18 -6.5" />
+                </svg>
+              </span>
+              </button>
             </div>
           </form>
         </div>
@@ -392,7 +1213,25 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 text-sm text-slate-600">
       <div class="grid md:grid-cols-3 gap-6">
         <div>
-          <div class="flex items-center gap-2 font-semibold"><div class="h-7 w-7 rounded-xl bg-slate-900 grid place-items-center"><i data-lucide="blocks" class="h-4 w-4 text-white"></i></div> Step3D.Lab</div>
+          <div class="flex items-center gap-2 font-semibold"><div class="h-7 w-7 rounded-xl bg-slate-900 grid place-items-center">
+          <span class="icon h-4 w-4 text-white" aria-hidden="true">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <title>Эмблема Step3D.Lab</title>
+              <path d="M14 4a1 1 0 0 1 1 -1h5a1 1 0 0 1 1 1v5a1 1 0 0 1 -1 1h-5a1 1 0 0 1 -1 -1z" />
+              <path d="M3 14h12a2 2 0 0 1 2 2v3a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h3a2 2 0 0 1 2 2v12" />
+            </svg>
+          </span>
+          </div> Step3D.Lab</div>
           <p class="mt-2 text-slate-500">Лаборатория промдизайна и инжиниринга. Технопарк РГСУ.</p>
         </div>
         <div class="grid grid-cols-2 gap-6">

--- a/styles/icons.css
+++ b/styles/icons.css
@@ -1,0 +1,48 @@
+:root {
+  --icon-stroke-color: currentColor;
+  --icon-hover-stroke-color: currentColor;
+  --icon-hover-scale: 1.05;
+  --icon-transition-duration: 200ms;
+}
+
+[data-theme="dark"] {
+  --icon-stroke-color: currentColor;
+  --icon-hover-stroke-color: currentColor;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  color: inherit;
+  transition: transform var(--icon-transition-duration) ease, color var(--icon-transition-duration) ease;
+}
+
+.icon svg {
+  display: block;
+  width: 1em;
+  height: 1em;
+  stroke: var(--icon-stroke-color);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  transition: inherit;
+}
+
+.icon:hover,
+.icon:focus-visible {
+  transform: scale(var(--icon-hover-scale));
+  color: var(--icon-hover-stroke-color);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon {
+    transition: none;
+  }
+
+  .icon:hover,
+  .icon:focus-visible {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add Tabler icon assets and an icon utility stylesheet with hover and dark-mode styling
- inline Tabler SVGs across the landing page and preload the above-the-fold icons, eliminating the Lucide CDN dependency
- drop the Lucide initialization call from the main script since icons are now static markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d969b22464833391b1707cb94f0daa