### PR TITLE
Add GenAI logo showcase section

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -9,3 +9,46 @@
 /* Анимация появления блоков при прокрутке */
 .reveal { opacity: 0; transform: translateY(20px); transition: opacity .6s, transform .6s; }
 .reveal.in { opacity: 1; transform: none; }
+
+/* Сетка логотипов раздела GenAI + Open Source */
+#logos .logos-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+#logos .logo-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+#logos .logo-card img {
+  max-width: 120px;
+  width: 100%;
+  height: auto;
+  transition: transform 0.3s ease;
+}
+
+#logos .logo-card figcaption {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #333;
+}
+
+#logos .logo-card:hover img {
+  transform: scale(1.05);
+}
+
+@media (min-width: 640px) {
+  #logos .logos-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  #logos .logos-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/index.html
+++ b/index.html
@@ -251,6 +251,43 @@
     <section id="tools" class="py-16">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">GenAI + Open Source</h2>
+        <!-- Блок логотипов инструментов: сетка с официальными изображениями -->
+        <section id="logos" class="mt-8">
+          <div class="logos-grid">
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Perplexity_AI_logo.svg" alt="Логотип Perplexity" loading="lazy" />
+              <figcaption>Perplexity</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Qwen_logo.svg" alt="Логотип Qwen AI" loading="lazy" />
+              <figcaption>Qwen AI</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_Blender.svg" alt="Логотип Blender" loading="lazy" />
+              <figcaption>Blender</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/FreeCAD-logo.svg" alt="Логотип FreeCAD" loading="lazy" />
+              <figcaption>FreeCAD</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Openscad.svg" alt="Логотип OpenSCAD" loading="lazy" />
+              <figcaption>OpenSCAD</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Hf-logo-with-title.svg" alt="Логотип Hugging Face" loading="lazy" />
+              <figcaption>Hugging Face</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_TFLEX_CAD.png" alt="Логотип T-FLEX CAD" loading="lazy" />
+              <figcaption>T‑FLEX CAD</figcaption>
+            </figure>
+            <figure class="logo-card">
+              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/NotebookLM_logo.svg" alt="Логотип NotebookLM" loading="lazy" />
+              <figcaption>NotebookLM</figcaption>
+            </figure>
+          </div>
+        </section>
         <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           <a href="https://www.perplexity.ai/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add a dedicated logos section under the "GenAI + Open Source" heading
- style the logo grid to stay responsive and include hover scaling for the icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97342276c8333a82a1fe1a04021a4