### PR TITLE
Revamp GenAI + Open Source section layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -10,50 +10,209 @@
 .reveal { opacity: 0; transform: translateY(20px); transition: opacity .6s, transform .6s; }
 .reveal.in { opacity: 1; transform: none; }
 
-/* Сетка логотипов раздела GenAI + Open Source */
-#logos .logos-grid {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-#logos .logo-card {
-  display: flex;
-  flex-direction: column;
+/* Современный блок GenAI + Open Source */
+.tools-badge {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  padding: 1.5rem 1.25rem;
-  border-radius: 1.5rem;
-  border: 1px solid #e2e8f0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.9) 100%);
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.06);
-  text-align: center;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-#logos .logo-card img {
-  max-width: 120px;
-  max-height: 72px;
-  width: auto;
-  height: auto;
-  object-fit: contain;
-  filter: drop-shadow(0 6px 18px rgba(15, 23, 42, 0.08));
-  transition: transform 0.3s ease;
-}
-
-#logos .logo-card figcaption {
-  font-size: 0.9rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  background: rgba(79, 70, 229, 0.08);
+  color: #4338ca;
   font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.tools-badge::before {
+  content: '';
+  display: block;
+  height: 0.45rem;
+  width: 0.45rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6366f1 0%, #0ea5e9 100%);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.15);
+}
+
+.tools-gradient-text {
+  display: inline-block;
+  background: linear-gradient(135deg, #4f46e5 0%, #0ea5e9 40%, #14b8a6 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tools-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.06);
   color: #1e293b;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.tools-chip::before {
+  content: '';
+  display: block;
+  height: 0.35rem;
+  width: 0.35rem;
+  border-radius: 9999px;
+  background: currentColor;
+  opacity: 0.4;
+}
+
+.tools-chip:hover {
+  background: rgba(79, 70, 229, 0.08);
+  border-color: rgba(99, 102, 241, 0.45);
+  color: #4338ca;
+}
+
+#logos .logo-cloud {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+#logos .logo-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 18px 32px -20px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(6px);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+#logos .logo-pill img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 20px rgba(15, 23, 42, 0.08));
+}
+
+#logos .logo-pill span {
+  font-weight: 600;
+  color: #0f172a;
   letter-spacing: 0.01em;
 }
 
-#logos .logo-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+#logos .logo-pill:hover {
+  transform: translateY(-4px) scale(1.01);
+  box-shadow: 0 24px 40px -20px rgba(79, 70, 229, 0.4);
 }
 
-#logos .logo-card:hover img {
-  transform: scale(1.05);
+.tools-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.6rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: radial-gradient(120% 120% at 0% 0%, rgba(99, 102, 241, 0.12) 0%, rgba(15, 23, 42, 0.02) 55%, rgba(15, 23, 42, 0.04) 100%);
+  box-shadow: 0 20px 45px -30px rgba(15, 23, 42, 0.5);
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.tools-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.5), rgba(14, 165, 233, 0.4)) border-box;
+  mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.tools-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(99, 102, 241, 0.45);
+  box-shadow: 0 30px 60px -35px rgba(79, 70, 229, 0.55);
+}
+
+.tools-card:hover::after,
+.tools-card:focus-visible::after,
+.tools-card:focus::after {
+  opacity: 1;
+}
+
+.tools-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.tools-card__logo {
+  height: 52px;
+  width: 52px;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5), 0 10px 20px -15px rgba(15, 23, 42, 0.6);
+}
+
+.tools-card__logo img {
+  max-height: 32px;
+  max-width: 32px;
+  object-fit: contain;
+}
+
+.tools-card__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+  letter-spacing: -0.01em;
+}
+
+.tools-card__tag {
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6366f1;
+}
+
+.tools-card__description {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.tools-card__cta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #4338ca;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.tools-card__cta::after {
+  content: '↗';
+  font-size: 0.9rem;
+}
+
+.tools-card:hover .tools-card__cta,
+.tools-card:focus-visible .tools-card__cta {
+  color: #1d4ed8;
+  transform: translateX(2px);
 }

--- a/index.html
+++ b/index.html
@@ -248,102 +248,156 @@
     </section>
 
     <!-- Рекомендованные инструменты (кликабельные карточки) -->
-    <section id="tools" class="py-16">
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <h2 class="text-3xl sm:text-4xl font-bold tracking-tight">GenAI + Open Source</h2>
-        <!-- Блок логотипов инструментов: сетка с официальными изображениями -->
-        <section id="logos" class="mt-8">
-          <div class="logos-grid">
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Perplexity_AI_logo.svg" alt="Логотип Perplexity" loading="lazy" />
-              <figcaption>Perplexity</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Qwen_logo.svg" alt="Логотип Qwen AI" loading="lazy" />
-              <figcaption>Qwen AI</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_Blender.svg" alt="Логотип Blender" loading="lazy" />
-              <figcaption>Blender</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/FreeCAD-logo.svg" alt="Логотип FreeCAD" loading="lazy" />
-              <figcaption>FreeCAD</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Openscad.svg" alt="Логотип OpenSCAD" loading="lazy" />
-              <figcaption>OpenSCAD</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Hf-logo-with-title.svg" alt="Логотип Hugging Face" loading="lazy" />
-              <figcaption>Hugging Face</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_TFLEX_CAD.png" alt="Логотип T-FLEX CAD" loading="lazy" />
-              <figcaption>T‑FLEX CAD</figcaption>
-            </figure>
-            <figure class="logo-card">
-              <img src="https://commons.wikimedia.org/wiki/Special:FilePath/NotebookLM_logo.svg" alt="Логотип NotebookLM" loading="lazy" />
-              <figcaption>NotebookLM</figcaption>
-            </figure>
+    <section id="tools" class="relative overflow-hidden py-20">
+      <div aria-hidden class="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-b from-white via-slate-50/60 to-white">
+        <div class="absolute -top-40 right-10 h-72 w-72 rounded-full bg-indigo-200/40 blur-3xl"></div>
+        <div class="absolute bottom-0 left-10 h-64 w-64 rounded-full bg-sky-200/40 blur-3xl"></div>
+      </div>
+      <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col gap-12 lg:flex-row lg:items-start">
+          <div class="max-w-2xl">
+            <span class="tools-badge">Экосистема инструментов</span>
+            <h2 class="mt-4 text-3xl sm:text-4xl font-bold tracking-tight">
+              GenAI <span class="text-slate-400">+</span>
+              <span class="tools-gradient-text">Open Source</span>
+            </h2>
+            <p class="mt-4 text-lg text-slate-600">
+              Подборка сервисов, с которыми команда Step3D.Lab решает задачи исследования, моделирования и презентации.
+              Мы комбинируем генеративный ИИ и открытые CAD‑инструменты, чтобы ускорять цикл «идея → прототип → внедрение».
+            </p>
+            <div class="mt-6 flex flex-wrap gap-2 text-sm">
+              <span class="tools-chip">Research &amp; analytics</span>
+              <span class="tools-chip">3D modeling</span>
+              <span class="tools-chip">Collaboration</span>
+              <span class="tools-chip">Documentation</span>
+            </div>
           </div>
-        </section>
-        <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          <a href="https://www.perplexity.ai/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/perplexity-ai.svg" alt="Perplexity AI логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">Perplexity AI</div>
+          <div id="logos" class="w-full lg:max-w-md">
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Используем в проектах</p>
+            <div class="logo-cloud">
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Perplexity_AI_logo.svg" alt="Логотип Perplexity" loading="lazy" />
+                <span>Perplexity</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Qwen_logo.svg" alt="Логотип Qwen AI" loading="lazy" />
+                <span>Qwen</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_Blender.svg" alt="Логотип Blender" loading="lazy" />
+                <span>Blender</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/FreeCAD-logo.svg" alt="Логотип FreeCAD" loading="lazy" />
+                <span>FreeCAD</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Openscad.svg" alt="Логотип OpenSCAD" loading="lazy" />
+                <span>OpenSCAD</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Hf-logo-with-title.svg" alt="Логотип Hugging Face" loading="lazy" />
+                <span>Hugging Face</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/Logo_TFLEX_CAD.png" alt="Логотип T-FLEX CAD" loading="lazy" />
+                <span>T‑FLEX CAD</span>
+              </div>
+              <div class="logo-pill">
+                <img src="https://commons.wikimedia.org/wiki/Special:FilePath/NotebookLM_logo.svg" alt="Логотип NotebookLM" loading="lazy" />
+                <span>NotebookLM</span>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">AI‑поиск и аналитика для исследований и брифов.</div>
+          </div>
+        </div>
+        <div class="mt-14 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <a href="https://www.perplexity.ai/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/perplexity-ai.svg" alt="Perplexity AI логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">Perplexity AI</div>
+                <div class="tools-card__tag">Research &amp; briefs</div>
+              </div>
+            </div>
+            <p class="tools-card__description">AI‑поиск и аналитика для быстрых исследований, синтеза инсайтов и подготовки брифов.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://qwenlm.ai/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/qwen-ai.svg" alt="Qwen AI логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">Qwen AI</div>
+          <a href="https://qwenlm.ai/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/qwen-ai.svg" alt="Qwen AI логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">Qwen AI</div>
+                <div class="tools-card__tag">Multimodal studio</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Мультимодальные модели Alibaba для генерации контента и кода.</div>
+            <p class="tools-card__description">Мультимодальные модели Alibaba для генерации текстов, кода и ассетов под задачи проекта.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://www.blender.org/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/blender.svg" alt="Blender логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">Blender</div>
+          <a href="https://www.blender.org/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/blender.svg" alt="Blender логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">Blender</div>
+                <div class="tools-card__tag">3D creation suite</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Открытый пакет для 3D‑моделирования, анимации и рендера.</div>
+            <p class="tools-card__description">Открытый пакет для 3D‑моделирования, анимации и рендера с огромной экосистемой аддонов.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://www.freecad.org/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/freecad.svg" alt="FreeCAD логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">FreeCAD</div>
+          <a href="https://www.freecad.org/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/freecad.svg" alt="FreeCAD логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">FreeCAD</div>
+                <div class="tools-card__tag">Parametric CAD</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Параметрический CAD‑пакет с открытым исходным кодом.</div>
+            <p class="tools-card__description">Параметрический CAD с открытым исходным кодом: библиотека workbench и инженерные плагины.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://openscad.org/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/openscad.svg" alt="OpenSCAD логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">OpenSCAD</div>
+          <a href="https://openscad.org/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/openscad.svg" alt="OpenSCAD логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">OpenSCAD</div>
+                <div class="tools-card__tag">Code-based CAD</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Скриптовый CAD для точных параметрических моделей.</div>
+            <p class="tools-card__description">Скриптовый CAD для точных параметрических моделей и библиотек компонентов.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://huggingface.co/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/hugging-face.svg" alt="Hugging Face логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">Hugging Face</div>
+          <a href="https://huggingface.co/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/hugging-face.svg" alt="Hugging Face логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">Hugging Face</div>
+                <div class="tools-card__tag">Model hub</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Маркетплейс моделей ИИ и инструменты для экспериментов.</div>
+            <p class="tools-card__description">Маркетплейс моделей ИИ и наборы инструментов для экспериментов, обучения и продакшена.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://www.tflex.com/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/t-flex-cad.svg" alt="T‑FLEX CAD логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">T‑FLEX CAD</div>
+          <a href="https://www.tflex.com/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/t-flex-cad.svg" alt="T‑FLEX CAD логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">T‑FLEX CAD</div>
+                <div class="tools-card__tag">Production ready</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Профессиональный параметрический CAD российского производства.</div>
+            <p class="tools-card__description">Профессиональный параметрический CAD российского производства с PLM‑экосистемой.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
-          <a href="https://notebooklm.google/" target="_blank" rel="noopener" class="group rounded-3xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
-            <div class="flex items-center gap-3">
-              <img src="assets/logos/svg/notebooklm.svg" alt="NotebookLM логотип" loading="lazy" class="h-10 w-10 flex-shrink-0 rounded-xl border border-slate-200 bg-white p-1" />
-              <div class="text-lg font-semibold group-hover:text-indigo-700">NotebookLM</div>
+          <a href="https://notebooklm.google/" target="_blank" rel="noopener" class="tools-card group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
+            <div class="tools-card__header">
+              <div class="tools-card__logo"><img src="assets/logos/svg/notebooklm.svg" alt="NotebookLM логотип" loading="lazy" /></div>
+              <div>
+                <div class="tools-card__title">NotebookLM</div>
+                <div class="tools-card__tag">Knowledge base</div>
+              </div>
             </div>
-            <div class="mt-3 text-slate-600 text-sm">Google‑сервис заметок и исследований на основе ваших источников.</div>
+            <p class="tools-card__description">Google‑сервис заметок и исследований на основе ваших источников с умным ассистентом.</p>
+            <span class="tools-card__cta">Открыть сервис →</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign the "GenAI + Open Source" block with a new split layout, descriptive copy, and chip badges for key scenarios
- replace the logo grid and tool cards styling to more modern pill and gradient card components backed by custom CSS updates

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9758281b88333bb81738a031b3d97