### PR TITLE
Redesign tools section with real clickable logos

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -452,17 +452,6 @@ section {
   gap: 16px;
 }
 
-.card.link {
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 18px;
-}
-
-.card.link img {
-  width: 48px;
-  height: 48px;
-}
-
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
@@ -492,28 +481,63 @@ section {
   background: var(--color-accent-soft);
 }
 
-.logo-band {
+
+.tool-grid {
   display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  padding: 24px;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.tool-card {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 22px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   box-shadow: var(--shadow-xs);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.logo-band figure {
+.tool-card:hover,
+.tool-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-sm);
+  border-color: var(--color-accent);
+}
+
+.tool-card__logo {
+  width: 72px;
+  height: 72px;
   display: grid;
-  gap: 10px;
-  justify-items: center;
-  font-size: 0.9rem;
-  color: var(--color-muted);
+  place-items: center;
+  border-radius: 20px;
+  overflow: hidden;
 }
 
-.logo-band img {
-  width: 64px;
-  height: 64px;
+.tool-card__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tool-card__body {
+  display: grid;
+  gap: 8px;
+}
+
+.tool-card__body h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.tool-card__body p {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
 }
 
 .bullet-list {

--- a/assets/logos/svg/blender.svg
+++ b/assets/logos/svg/blender.svg
@@ -1,5 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>BL placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#fff7ed" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#c2410c">BL</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>Blender логотип</title>
+  <defs>
+    <linearGradient id="blender-body" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff9a2b" />
+      <stop offset="100%" stop-color="#ff6b00" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="120" rx="26" fill="#0b1c2c" />
+  <path fill="url(#blender-body)" d="M52 28c-5 0-7.1 6.4-3.1 9.4l18.5 13.7H46c-4.8 0-7.2 6-3.5 9.3L65.8 87.6c3.7 3.3 9.4 3.3 13.1 0l20-18c8.7-7.9 9.6-21.1 2-30.1-4.2-5-10.4-7.9-17-7.9H52z" />
+  <circle cx="101" cy="63" r="22" fill="#1f4ae0" />
+  <circle cx="101" cy="63" r="12" fill="#8bd4ff" />
 </svg>

--- a/assets/logos/svg/freecad.svg
+++ b/assets/logos/svg/freecad.svg
@@ -1,5 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>FC placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#eff6ff" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#1d4ed8">FC</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>FreeCAD логотип</title>
+  <rect width="160" height="120" rx="24" fill="#11243a" />
+  <path fill="#f44336" d="M54 28h27c5 0 9 4 9 9v18h-23v-8h-13v46H39V41c0-7.2 5.8-13 13-13z" />
+  <path fill="#1e88e5" d="M86 56h17l18 18v22h-17V84h-18V56z" />
+  <path fill="#90caf9" d="M103 74h18l-18-18v18z" />
+  <circle cx="66" cy="42" r="6" fill="#fff" />
 </svg>

--- a/assets/logos/svg/hugging-face.svg
+++ b/assets/logos/svg/hugging-face.svg
@@ -1,5 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>HF placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#fce7f3" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#db2777">HF</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>Hugging Face логотип</title>
+  <rect width="160" height="120" rx="24" fill="#fff7e6" />
+  <circle cx="80" cy="60" r="38" fill="#ffcc4d" />
+  <path fill="#664500" d="M64 56a6 6 0 1 1 12 0 6 6 0 0 1-12 0zm20 0a6 6 0 1 1 12 0 6 6 0 0 1-12 0z" />
+  <path fill="#664500" d="M80 90c-12.2 0-22.6-7.8-26.4-18.7-.7-2 1-4.1 3.2-4.1h46.4c2.2 0 3.9 2.1 3.2 4.1C102.6 82.2 92.2 90 80 90z" />
+  <path fill="#ffac33" d="M45 92c-6 0-11-4-12.4-9.6-.5-2 1.1-3.9 3.2-3.9h17.6c2.1 0 3.7 1.9 3.2 3.9C55.2 88 50.6 92 45 92zm70 0c-5.6 0-10.2-4-11.6-9.6-.5-2 1.1-3.9 3.2-3.9h17.6c2.1 0 3.7 1.9 3.2 3.9C125 88 120 92 115 92z" />
 </svg>

--- a/assets/logos/svg/notebooklm.svg
+++ b/assets/logos/svg/notebooklm.svg
@@ -1,5 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>NL placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#e0f2fe" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#0369a1">NL</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>NotebookLM логотип</title>
+  <rect width="160" height="120" rx="24" fill="#0d1b2a" />
+  <path fill="#4285f4" d="M44 30h36c8.8 0 16 7.2 16 16v48H60c-8.8 0-16-7.2-16-16V30z" />
+  <path fill="#34a853" d="M120 30H96c-8.8 0-16 7.2-16 16v48h40c8.8 0 16-7.2 16-16V46c0-8.8-7.2-16-16-16z" />
+  <path fill="#fbbc04" d="M80 30h16v50c0 5.5-4.5 10-10 10h-6V30z" />
+  <path fill="#ea4335" d="M80 30H64v50c0 5.5 4.5 10 10 10h6V30z" />
+  <circle cx="64" cy="48" r="6" fill="#fff" opacity="0.85" />
+  <circle cx="96" cy="48" r="6" fill="#fff" opacity="0.85" />
 </svg>

--- a/assets/logos/svg/openscad.svg
+++ b/assets/logos/svg/openscad.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>OS placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#fef9c3" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#ca8a04">OS</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>OpenSCAD логотип</title>
+  <rect width="160" height="120" rx="24" fill="#202020" />
+  <polygon points="80 20 122 44 122 96 80 116 38 92 38 40" fill="#ffce1f" />
+  <path fill="#202020" d="M80 46l-22 12v24l22 12 22-12V58L80 46zm0 10l12 6v12l-12 6-12-6V62l12-6z" />
 </svg>

--- a/assets/logos/svg/perplexity-ai.svg
+++ b/assets/logos/svg/perplexity-ai.svg
@@ -1,5 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>PA placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#eef2ff" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#3730a3">PA</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img">
+  <title>Perplexity AI логотип</title>
+  <defs>
+    <linearGradient id="perplexity-gradient" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#00c4ff" />
+      <stop offset="50%" stop-color="#6959ff" />
+      <stop offset="100%" stop-color="#ff4ecd" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="52" fill="#0b1120" />
+  <path fill="none" stroke="url(#perplexity-gradient)" stroke-width="10" stroke-linecap="round" d="M86 28c-12.8-8.7-30.2-8-42.1 2.1C31 43 29.6 63.4 41 77.6c12.4 15.6 36 17.2 51.2 3.4" />
+  <path fill="none" stroke="url(#perplexity-gradient)" stroke-width="10" stroke-linecap="round" d="M34 92c8.5 6.2 19.5 8.7 30 6.8 10.4-1.8 19.6-7.9 25.2-16.8" opacity="0.75" />
+  <circle cx="82" cy="38" r="8" fill="#fff" />
 </svg>

--- a/assets/logos/svg/qwen-ai.svg
+++ b/assets/logos/svg/qwen-ai.svg
@@ -1,5 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>QW placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#ecfdf5" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#047857">QW</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img">
+  <title>Qwen AI логотип</title>
+  <defs>
+    <linearGradient id="qwen-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00f2fe" />
+      <stop offset="40%" stop-color="#4facfe" />
+      <stop offset="100%" stop-color="#736efe" />
+    </linearGradient>
+  </defs>
+  <rect x="10" y="10" width="100" height="100" rx="26" fill="#050816" />
+  <path fill="url(#qwen-gradient)" d="M60 22c-21 0-38 17-38 38s17 38 38 38c8.9 0 17-3 23.5-8.1l-12.2-12.2c-3.1 2.2-6.9 3.4-11.3 3.4-10.3 0-18.7-8.4-18.7-18.7S49.7 33.3 60 33.3c6.7 0 12.4 3.4 15.8 8.6l12.4-12.4C80.7 25.5 70.9 22 60 22z" />
+  <path fill="#ffffff" opacity="0.9" d="M76.5 58.2c1.2 2.1 1.9 4.6 1.9 7.1 0 3.6-1.2 6.9-3.2 9.5l12 12c4.9-5.9 7.8-13.5 7.8-21.5 0-8-2.9-15.4-7.7-21.2l-12 12c0.5 0.9 0.9 1.9 1.2 2.9z" />
+  <circle cx="60" cy="60" r="11" fill="#111b46" />
 </svg>

--- a/assets/logos/svg/t-flex-cad.svg
+++ b/assets/logos/svg/t-flex-cad.svg
@@ -1,5 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" role="img">
-  <title>TF placeholder</title>
-  <rect width="160" height="80" rx="18" fill="#f1f5f9" />
-  <text x="80" y="50" text-anchor="middle" font-family="'Inter', 'Segoe UI', Arial, sans-serif" font-size="32" font-weight="700" fill="#0f172a">TF</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img">
+  <title>T-FLEX CAD логотип</title>
+  <rect width="160" height="120" rx="24" fill="#041225" />
+  <path fill="#0f62fe" d="M36 36h40v16H64v48H48V52H36V36z" />
+  <path fill="#ffffff" d="M82 48h44v12H82z" />
+  <path fill="#0f62fe" d="M82 66h18c8.3 0 15 6.7 15 15s-6.7 15-15 15H82z" />
+  <rect x="102" y="72" width="20" height="18" rx="9" fill="#ffffff" />
 </svg>

--- a/index.html
+++ b/index.html
@@ -241,95 +241,77 @@
           <h2>GenAI и open source инструменты</h2>
           <p>Работаем с открытым ПО и ИИ‑помощниками — от генерации идей до построения цифровых двойников.</p>
         </div>
-        <div class="logo-band">
-          <figure>
-            <img src="assets/logos/svg/perplexity-ai.svg" alt="Perplexity AI логотип" loading="lazy" />
-            <figcaption>Perplexity</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/qwen-ai.svg" alt="Qwen AI логотип" loading="lazy" />
-            <figcaption>Qwen AI</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/blender.svg" alt="Blender логотип" loading="lazy" />
-            <figcaption>Blender</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/freecad.svg" alt="FreeCAD логотип" loading="lazy" />
-            <figcaption>FreeCAD</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/openscad.svg" alt="OpenSCAD логотип" loading="lazy" />
-            <figcaption>OpenSCAD</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/hugging-face.svg" alt="Hugging Face логотип" loading="lazy" />
-            <figcaption>Hugging Face</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/t-flex-cad.svg" alt="T-FLEX CAD логотип" loading="lazy" />
-            <figcaption>T‑FLEX CAD</figcaption>
-          </figure>
-          <figure>
-            <img src="assets/logos/svg/notebooklm.svg" alt="NotebookLM логотип" loading="lazy" />
-            <figcaption>NotebookLM</figcaption>
-          </figure>
-        </div>
-        <div class="card-grid tight">
-          <a class="card link" href="https://www.perplexity.ai/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/perplexity-ai.svg" alt="Perplexity AI" />
-            <div>
+        <div class="tool-grid">
+          <a class="tool-card" href="https://www.perplexity.ai/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/perplexity-ai.svg" alt="Perplexity AI логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>Perplexity AI</h3>
-              <p>Поиск и аналитика на основе ИИ для исследований.</p>
+              <p>ИИ‑поиск и аналитика с быстрым сбором источников и фактчекингом.</p>
             </div>
           </a>
-          <a class="card link" href="https://qwenlm.ai/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/qwen-ai.svg" alt="Qwen AI" />
-            <div>
+          <a class="tool-card" href="https://qwenlm.ai/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/qwen-ai.svg" alt="Qwen AI логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>Qwen AI</h3>
-              <p>Мультимодальные модели для генерации контента и кода.</p>
+              <p>Мультимодальные модели Alibaba Cloud для генерации текста, кода и графики.</p>
             </div>
           </a>
-          <a class="card link" href="https://www.blender.org/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/blender.svg" alt="Blender" />
-            <div>
+          <a class="tool-card" href="https://www.blender.org/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/blender.svg" alt="Blender логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>Blender</h3>
-              <p>Открытый пакет для 3D‑моделирования и визуализации.</p>
+              <p>Открытый пакет для 3D‑моделирования, анимации, рендера и композитинга.</p>
             </div>
           </a>
-          <a class="card link" href="https://www.freecad.org/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/freecad.svg" alt="FreeCAD" />
-            <div>
+          <a class="tool-card" href="https://www.freecad.org/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/freecad.svg" alt="FreeCAD логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>FreeCAD</h3>
-              <p>Параметрический CAD для инженерных задач и CAM.</p>
+              <p>Параметрический CAD для инженерных проектов, CAM‑подготовки и BIM.</p>
             </div>
           </a>
-          <a class="card link" href="https://openscad.org/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/openscad.svg" alt="OpenSCAD" />
-            <div>
+          <a class="tool-card" href="https://openscad.org/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/openscad.svg" alt="OpenSCAD логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>OpenSCAD</h3>
-              <p>Скриптовый CAD для точного параметрического моделинга.</p>
+              <p>Скриптовый CAD для точного параметрического моделинга и генераторов.</p>
             </div>
           </a>
-          <a class="card link" href="https://huggingface.co/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/hugging-face.svg" alt="Hugging Face" />
-            <div>
+          <a class="tool-card" href="https://huggingface.co/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/hugging-face.svg" alt="Hugging Face логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>Hugging Face</h3>
-              <p>Платформа моделей и инструментов машинного обучения.</p>
+              <p>Экосистема моделей, датасетов и Spaces для ML‑инженеров и исследователей.</p>
             </div>
           </a>
-          <a class="card link" href="https://www.tflex.com/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/t-flex-cad.svg" alt="T-FLEX CAD" />
-            <div>
+          <a class="tool-card" href="https://www.tflex.com/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/t-flex-cad.svg" alt="T‑FLEX CAD логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>T‑FLEX CAD</h3>
-              <p>Профессиональный российский параметрический CAD.</p>
+              <p>Российская CAD/CAM/PLM‑платформа для машиностроения и приборостроения.</p>
             </div>
           </a>
-          <a class="card link" href="https://notebooklm.google/" target="_blank" rel="noopener">
-            <img src="assets/logos/svg/notebooklm.svg" alt="NotebookLM" />
-            <div>
+          <a class="tool-card" href="https://notebooklm.google/" target="_blank" rel="noopener">
+            <figure class="tool-card__logo">
+              <img src="assets/logos/svg/notebooklm.svg" alt="NotebookLM логотип" loading="lazy" />
+            </figure>
+            <div class="tool-card__body">
               <h3>NotebookLM</h3>
-              <p>Google‑сервис заметок и исследований на базе ваших источников.</p>
+              <p>ИИ‑ассистент Google для работы с заметками, конспектами и исследованиями.</p>
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Summary
- replace the GenAI/tools section with a single grid of clickable cards that combine logos and descriptions without duplication
- add custom styles for the new tool cards and remove unused placeholder styles
- draw branded SVG logos for each highlighted product instead of temporary placeholders

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de9270003c83338f6dc5572825b546