### PR TITLE
Replace text logo with Step3D image asset

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -131,6 +131,12 @@ section {
   letter-spacing: -0.01em;
 }
 
+.brand-logo {
+  display: block;
+  height: 44px;
+  width: auto;
+}
+
 .brand-icon {
   display: grid;
   place-items: center;

--- a/index.html
+++ b/index.html
@@ -16,10 +16,7 @@
   <header class="site-header" id="top">
     <div class="container header-bar">
       <a class="brand" href="#top">
-        <span class="brand-icon">
-          <span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-step3d-lab.svg')"></span>
-        </span>
-        <span class="brand-name">Step3D.Lab</span>
+        <img class="brand-logo" src="images/Logo_Step_3D.jpg" alt="Step3D.Lab" />
       </a>
       <nav class="desktop-nav" aria-label="Основные ссылки">
         <a href="#features">Возможности</a>
@@ -550,10 +547,7 @@
     <div class="container footer-grid">
       <div>
         <a class="brand" href="#top">
-          <span class="brand-icon">
-            <span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-step3d-lab.svg')"></span>
-          </span>
-          <span class="brand-name">Step3D.Lab</span>
+          <img class="brand-logo" src="images/Logo_Step_3D.jpg" alt="Step3D.Lab" />
         </a>
         <p>Лаборатория промдизайна и инжиниринга. Технопарк РГСУ.</p>
       </div>


### PR DESCRIPTION
## Summary
- replace the header and footer brand markup with the Step3D.Lab image
- add styling for the new logo asset to control its display size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de96ab8b9483338398b5bab60f22a6