### PR TITLE
Add interactive equipment specs modal

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -481,6 +481,252 @@ section {
   background: var(--color-accent-soft);
 }
 
+[data-equip-item] {
+  position: relative;
+  cursor: pointer;
+  isolation: isolate;
+  outline: none;
+}
+
+[data-equip-item]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--color-accent-soft);
+  opacity: 0;
+  transition: opacity var(--transition);
+  z-index: -1;
+}
+
+[data-equip-item]:hover::after,
+[data-equip-item]:focus-visible::after {
+  opacity: 1;
+}
+
+[data-equip-item]:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.equipment-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 160;
+  display: grid;
+  place-items: center;
+  padding: clamp(24px, 4vw, 48px);
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(18px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity var(--transition), visibility var(--transition);
+}
+
+.equipment-modal.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.equipment-modal__overlay {
+  position: absolute;
+  inset: 0;
+}
+
+.equipment-modal__dialog {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  background: linear-gradient(150deg, rgba(37, 99, 235, 0.12), rgba(15, 23, 42, 0) 70%)
+      var(--color-surface);
+  border-radius: clamp(18px, 3vw, 24px);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.22);
+  overflow: hidden;
+  padding: clamp(28px, 4vw, 40px);
+}
+
+.equipment-modal__glow {
+  position: absolute;
+  inset: -40% -40% auto;
+  height: 240px;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.24), transparent 65%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.equipment-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.equipment-modal__meta {
+  display: grid;
+  gap: 8px;
+}
+
+.equipment-modal__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-accent-dark);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.equipment-modal__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.equipment-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  transition: background var(--transition), transform var(--transition);
+}
+
+.equipment-modal__close .icon {
+  color: var(--color-muted);
+}
+
+.equipment-modal__close:hover,
+.equipment-modal__close:focus-visible {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.equipment-modal__close:hover .icon,
+.equipment-modal__close:focus-visible .icon {
+  color: #fff;
+}
+
+.equipment-modal__body {
+  margin-top: 24px;
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.equipment-modal__body h3 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.2vw, 2rem);
+  letter-spacing: -0.01em;
+}
+
+.equipment-modal__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 1rem;
+}
+
+.equipment-modal__content {
+  display: grid;
+  gap: clamp(20px, 4vw, 32px);
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.equipment-modal__table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.06);
+}
+
+.equipment-modal__table tr:nth-child(odd) {
+  background: rgba(37, 99, 235, 0.04);
+}
+
+.equipment-modal__table th,
+.equipment-modal__table td {
+  padding: 14px 18px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.equipment-modal__table th {
+  width: 38%;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.equipment-modal__table td {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.equipment-modal__highlights {
+  display: grid;
+  gap: 12px;
+}
+
+.equipment-modal__highlights h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.equipment-modal__chips {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+}
+
+.equipment-modal__chips li {
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 820px) {
+  .equipment-modal__content {
+    grid-template-columns: 1fr;
+  }
+
+  .equipment-modal__table th {
+    width: 45%;
+  }
+}
+
+@media (max-width: 600px) {
+  .equipment-modal {
+    padding: clamp(18px, 6vw, 32px);
+  }
+
+  .equipment-modal__dialog {
+    padding: clamp(22px, 6vw, 30px);
+    border-radius: 18px;
+  }
+
+  .equipment-modal__header {
+    align-items: center;
+  }
+}
+
 
 .tool-grid {
   display: grid;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setYear();
   initMobileMenu();
   initEquipmentFilter();
+  initEquipmentModal();
   initGalleryLightbox();
 });
 
@@ -70,6 +71,367 @@ function initEquipmentFilter() {
   });
 
   applyFilter(current);
+}
+
+function initEquipmentModal() {
+  const modal = document.querySelector('[data-equip-modal]');
+  const triggers = Array.from(document.querySelectorAll('[data-equip-item]'));
+  if (!modal || !triggers.length) return;
+
+  const dialog = modal.querySelector('[data-modal-dialog]');
+  const overlay = modal.querySelector('[data-modal-overlay]');
+  const closeBtn = modal.querySelector('[data-modal-close]');
+  const titleEl = modal.querySelector('[data-modal-title]');
+  const subtitleEl = modal.querySelector('[data-modal-subtitle]');
+  const badgeEl = modal.querySelector('[data-modal-badge]');
+  const descEl = modal.querySelector('[data-modal-description]');
+  const specsContainer = modal.querySelector('[data-modal-specs]');
+  const highlightsContainer = modal.querySelector('[data-modal-highlights]');
+  const highlightsSection = modal.querySelector('.equipment-modal__highlights');
+
+  if (
+    !dialog ||
+    !overlay ||
+    !closeBtn ||
+    !titleEl ||
+    !subtitleEl ||
+    !badgeEl ||
+    !descEl ||
+    !specsContainer ||
+    !highlightsContainer ||
+    !highlightsSection
+  ) {
+    return;
+  }
+
+  const equipmentDetails = {
+    'rangevision-neo': {
+      name: 'RangeVision NEO',
+      subtitle: 'Структурированный свет · настольная система',
+      badge: '3D‑сканер',
+      description:
+        'Компактное решение для цифрового копирования объектов малого и среднего размера: точность контроля геометрии и удобный поворотный стол в комплекте.',
+      specs: [
+        { label: 'Тип сканирования', value: 'Стерео‑камера, структурированный свет' },
+        { label: 'Область съёмки', value: '120 × 160 × 120 мм' },
+        { label: 'Точность', value: 'до 0,05 мм' },
+        { label: 'Скорость', value: 'до 500 000 точек/сек' },
+        { label: 'Экспорт данных', value: 'STL, OBJ, PLY, ASCII' }
+      ],
+      highlights: [
+        'Автокалибровка и поворотный стол',
+        'Прошивка RangeVision ScanCenter',
+        'Контроль геометрии и инспекция'
+      ]
+    },
+    'rangevision-spectrum': {
+      name: 'RangeVision Spectrum',
+      subtitle: 'Структурированный свет · три зоны точности',
+      badge: '3D‑сканер',
+      description:
+        'Гибкий сканер для предметов от 1 см до 3 м: перестраиваемая оптика, комплект маркеров и поддержка фотореалистичных текстур.',
+      specs: [
+        { label: 'Зоны съёмки', value: '120×160×120 мм · 240×320×240 мм · 520×860×520 мм' },
+        { label: 'Точность', value: 'до 0,04 мм' },
+        { label: 'Разрешение', value: 'до 0,06 мм' },
+        { label: 'Скорость съёмки', value: 'до 1 200 000 точек/сек' },
+        { label: 'Форматы', value: 'STL, OBJ, PLY, WRML, CSV' }
+      ],
+      highlights: [
+        'Три сменных оптических модуля',
+        'Текстурирование с помощью фотокамер',
+        'Полноценный комплект референсных маркеров'
+      ]
+    },
+    'artec-eva': {
+      name: 'Artec Eva',
+      subtitle: 'Ручной 3D‑сканер',
+      badge: '3D‑сканер',
+      description:
+        'Лёгкий портативный сканер для оперативной съёмки людей, интерьеров и сложных поверхностей с высокой скоростью кадров.',
+      specs: [
+        { label: 'Тип сканера', value: 'Структурированный свет' },
+        { label: 'Рабочее поле', value: '214 × 148 мм' },
+        { label: 'Точность', value: 'до 0,1 мм' },
+        { label: 'Скорость', value: '16 fps · до 2 млн точек/сек' },
+        { label: 'Вес устройства', value: '0,9 кг' }
+      ],
+      highlights: [
+        'Без маркеров и пудры',
+        'Автосшивка в Artec Studio',
+        'Сканирование людей и сложных форм'
+      ]
+    },
+    'ultimaker-3': {
+      name: 'Ultimaker 3',
+      subtitle: 'FDM‑принтер с двойной экструзией',
+      badge: '3D‑принтер',
+      description:
+        'Инженерный принтер для функциональных прототипов: печать двумя материалами, облачные проекты и калибровка по одному касанию.',
+      specs: [
+        { label: 'Рабочий объём', value: '197 × 215 × 200 мм (один экструдер), 197 × 215 × 165 мм (два экструдера)' },
+        { label: 'Диаметр сопла', value: '0,4 мм (сменные 0,25–0,8 мм)' },
+        { label: 'Материалы', value: 'PLA, Tough PLA, ABS, Nylon, CPE, PVA' },
+        { label: 'Температура сопла', value: 'до 280 °C' },
+        { label: 'ПО', value: 'Ultimaker Cura, Digital Factory' }
+      ],
+      highlights: [
+        'Двойная экструзия с растворимыми поддержками',
+        'Автокалибровка платформы',
+        'Сетевое управление и мониторинг'
+      ]
+    },
+    'designer-x': {
+      name: 'Picaso 3D Designer X',
+      subtitle: 'Промышленный FDM‑принтер',
+      badge: '3D‑принтер',
+      description:
+        'Закрытая камера и мощная система подачи обеспечивают стабильность печати инженерными пластиками для серийных задач.',
+      specs: [
+        { label: 'Рабочий объём', value: '360 × 360 × 610 мм' },
+        { label: 'Материалы', value: 'ABS, PLA, Nylon, PC, полиамиды, композиты' },
+        { label: 'Температура экструдера', value: 'до 410 °C' },
+        { label: 'Температура платформы', value: 'до 150 °C' },
+        { label: 'Особенности', value: 'Система JetSwitch, автокалибровка, HEPA‑фильтрация' }
+      ],
+      highlights: [
+        'Промышленная точность печати',
+        'Закрытая термостабильная камера',
+        'Два материала без потери скорости'
+      ]
+    },
+    formlabs: {
+      name: 'Formlabs (Form 3)',
+      subtitle: 'LFS/Laser SLA‑принтер',
+      badge: '3D‑принтер',
+      description:
+        'Высокоточная фотополимерная печать с широкой библиотекой инженерных смол: от гибких до жаропрочных.',
+      specs: [
+        { label: 'Рабочий объём', value: '145 × 145 × 185 мм' },
+        { label: 'Толщина слоя', value: '25–300 микрон' },
+        { label: 'Лазер', value: 'Точность позиционирования 25 мкм' },
+        { label: 'Материалы', value: 'Engineering, Tough, Durable, Flexible, Dental, Castable' },
+        { label: 'ПО', value: 'PreForm, Dashboard' }
+      ],
+      highlights: [
+        'Стабильная LFS‑оптика',
+        'Быстрая смена картриджей',
+        'Постобработка в Form Wash/Form Cure'
+      ]
+    },
+    'roland-mdx': {
+      name: 'Roland MDX‑40/50/540',
+      subtitle: '3‑осевая механическая обработка',
+      badge: 'CNC',
+      description:
+        'Компактные станки для прототипирования и подготовки оснастки: точная обработка пластика, древесины и мягких металлов.',
+      specs: [
+        { label: 'Рабочее поле', value: '305 × 305 × 105 мм (MDX‑40), до 500 × 400 × 155 мм (MDX‑540)' },
+        { label: 'Скорость шпинделя', value: '6 000 – 12 000 об/мин' },
+        { label: 'Материалы', value: 'ABS, воски, ПВХ, алюминий, латунь' },
+        { label: 'Повторяемость', value: '±0,02 мм' },
+        { label: 'Управление', value: 'SRP Player, G‑code, автосмена инструмента (MDX‑50)' }
+      ],
+      highlights: [
+        'Автоматическая смена инструмента',
+        'Встроенный сенсор измерения заготовки',
+        'Интеграция с CAD/CAM системами'
+      ]
+    },
+    'trotec-speedy-300': {
+      name: 'Trotec Speedy 300',
+      subtitle: 'CO₂‑лазер для резки и гравировки',
+      badge: 'Лазерный станок',
+      description:
+        'Универсальный лазер с высокой скоростью перемещений и системой Vision для точной маркировки и резки сложных контуров.',
+      specs: [
+        { label: 'Рабочее поле', value: '726 × 432 мм' },
+        { label: 'Макс. мощность', value: 'до 120 Вт CO₂' },
+        { label: 'Скорость перемещения', value: 'до 355 см/с' },
+        { label: 'Материалы', value: 'Акрил, дерево, кожа, стекло, анодированный металл' },
+        { label: 'Особенности', value: 'Atmos Assist, опция Vision, программное обеспечение JobControl' }
+      ],
+      highlights: [
+        'Система пылеудаления Atmos',
+        'Позиционирование с камерой Vision',
+        'Быстрый переключатель фокуса Flexx'
+      ]
+    }
+  };
+
+  const focusableSelector =
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])';
+
+  let lastFocused = null;
+
+  const isVisible = (element) => {
+    if (element.hidden) return false;
+    if (element.closest('[hidden]')) return false;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  };
+
+  const populateModal = (item) => {
+    titleEl.textContent = item.name;
+    subtitleEl.textContent = item.subtitle || '';
+    subtitleEl.hidden = !item.subtitle;
+    badgeEl.textContent = item.badge || '';
+    badgeEl.hidden = !item.badge;
+    descEl.textContent = item.description || '';
+    descEl.hidden = !item.description;
+
+    specsContainer.innerHTML = '';
+    (item.specs || []).forEach(spec => {
+      const row = document.createElement('tr');
+      const th = document.createElement('th');
+      const td = document.createElement('td');
+      th.scope = 'row';
+      th.textContent = spec.label;
+      td.textContent = spec.value;
+      row.append(th, td);
+      specsContainer.appendChild(row);
+    });
+
+    if (!specsContainer.children.length) {
+      const emptyRow = document.createElement('tr');
+      const th = document.createElement('th');
+      const td = document.createElement('td');
+      th.scope = 'row';
+      th.textContent = 'Характеристики';
+      td.textContent = 'Информация уточняется.';
+      emptyRow.append(th, td);
+      specsContainer.appendChild(emptyRow);
+    }
+
+    highlightsContainer.innerHTML = '';
+    const highlights = item.highlights || [];
+    highlightsSection.hidden = highlights.length === 0;
+    highlights.forEach(text => {
+      const chip = document.createElement('li');
+      chip.textContent = text;
+      highlightsContainer.appendChild(chip);
+    });
+  };
+
+  const getFocusableElements = () =>
+    Array.from(dialog.querySelectorAll(focusableSelector)).filter(isVisible);
+
+  const onKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeModal();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const focusable = getFocusableElements();
+      if (!focusable.length) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || active === dialog) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  const openModal = (id) => {
+    const item = equipmentDetails[id];
+    if (!item) return;
+
+    populateModal(item);
+    lastFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    modal.hidden = false;
+    dialog.scrollTop = 0;
+    requestAnimationFrame(() => {
+      modal.classList.add('is-visible');
+      dialog.focus();
+    });
+
+    document.body.dataset.lockScroll = 'true';
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', onKeyDown);
+  };
+
+  const closeModal = () => {
+    if (modal.classList.contains('is-visible')) {
+      modal.classList.remove('is-visible');
+    }
+
+    document.body.style.overflow = '';
+    delete document.body.dataset.lockScroll;
+    document.removeEventListener('keydown', onKeyDown);
+
+    let focusRestored = false;
+
+    const restoreFocus = () => {
+      if (!focusRestored) {
+        focusRestored = true;
+        if (lastFocused && typeof lastFocused.focus === 'function') {
+          lastFocused.focus();
+        }
+        lastFocused = null;
+      }
+    };
+
+    const hide = () => {
+      if (!modal.hidden) {
+        modal.hidden = true;
+      }
+      restoreFocus();
+    };
+
+    const onTransitionEnd = (event) => {
+      if (event.target === modal) {
+        modal.removeEventListener('transitionend', onTransitionEnd);
+        hide();
+      }
+    };
+
+    modal.addEventListener('transitionend', onTransitionEnd);
+    window.setTimeout(() => {
+      modal.removeEventListener('transitionend', onTransitionEnd);
+      if (!modal.hidden) {
+        hide();
+      } else {
+        restoreFocus();
+      }
+    }, 250);
+  };
+
+  triggers.forEach(trigger => {
+    const id = trigger.dataset.equipId;
+    if (!id) return;
+
+    const heading = trigger.querySelector('h3');
+    if (heading) {
+      trigger.setAttribute('aria-label', `Подробнее об оборудовании ${heading.textContent.trim()}`);
+    }
+
+    trigger.addEventListener('click', () => openModal(id));
+    trigger.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openModal(id);
+      }
+    });
+  });
+
+  overlay.addEventListener('click', closeModal);
+  closeBtn.addEventListener('click', closeModal);
 }
 
 function initGalleryLightbox() {

--- a/index.html
+++ b/index.html
@@ -163,7 +163,16 @@
           <button type="button" class="filter-button" data-filter="cnc">CNC и лазер</button>
         </div>
         <div id="equip-grid" class="card-grid">
-          <article class="card compact" data-equip-item data-type="scanners">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="scanners"
+            data-equip-id="rangevision-neo"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-3d-skanirovanie.svg')"></span></span>
               <div>
@@ -172,7 +181,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="scanners">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="scanners"
+            data-equip-id="rangevision-spectrum"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-3d-skanirovanie.svg')"></span></span>
               <div>
@@ -181,7 +199,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="scanners">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="scanners"
+            data-equip-id="artec-eva"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-3d-skanirovanie.svg')"></span></span>
               <div>
@@ -190,7 +217,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="printers">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="printers"
+            data-equip-id="ultimaker-3"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-additivnoe-proizvodstvo.svg')"></span></span>
               <div>
@@ -199,7 +235,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="printers">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="printers"
+            data-equip-id="designer-x"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-additivnoe-proizvodstvo.svg')"></span></span>
               <div>
@@ -208,7 +253,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="printers">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="printers"
+            data-equip-id="formlabs"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-additivnoe-proizvodstvo.svg')"></span></span>
               <div>
@@ -217,7 +271,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="cnc">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="cnc"
+            data-equip-id="roland-mdx"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-cad-cae-modelirovanie.svg')"></span></span>
               <div>
@@ -226,7 +289,16 @@
               </div>
             </header>
           </article>
-          <article class="card compact" data-equip-item data-type="cnc">
+          <article
+            class="card compact"
+            data-equip-item
+            data-type="cnc"
+            data-equip-id="trotec-speedy-300"
+            role="button"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-controls="equipment-modal"
+          >
             <header>
               <span class="icon-badge small"><span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-cad-cae-modelirovanie.svg')"></span></span>
               <div>
@@ -235,6 +307,42 @@
               </div>
             </header>
           </article>
+        </div>
+        <div class="equipment-modal" id="equipment-modal" data-equip-modal hidden>
+          <div class="equipment-modal__overlay" data-modal-overlay></div>
+          <div
+            class="equipment-modal__dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="equipment-modal-title"
+            aria-describedby="equipment-modal-description"
+            tabindex="-1"
+            data-modal-dialog
+          >
+            <div class="equipment-modal__glow" aria-hidden="true"></div>
+            <header class="equipment-modal__header">
+              <div class="equipment-modal__meta">
+                <span class="equipment-modal__badge" data-modal-badge></span>
+                <p class="equipment-modal__subtitle" data-modal-subtitle></p>
+              </div>
+              <button type="button" class="equipment-modal__close" aria-label="Закрыть" data-modal-close>
+                <span class="icon" aria-hidden="true" style="--icon-src: url('../assets/icons/custom/icon-zakryt-galereyu.svg')"></span>
+              </button>
+            </header>
+            <div class="equipment-modal__body">
+              <h3 id="equipment-modal-title" data-modal-title></h3>
+              <p class="equipment-modal__description" id="equipment-modal-description" data-modal-description></p>
+              <div class="equipment-modal__content">
+                <table class="equipment-modal__table">
+                  <tbody data-modal-specs></tbody>
+                </table>
+                <div class="equipment-modal__highlights">
+                  <h4>Ключевые преимущества</h4>
+                  <ul class="equipment-modal__chips" data-modal-highlights></ul>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- make each equipment card keyboard-accessible and ready to trigger detailed specs
- add a modern modal layout to present specification tables and key highlights
- implement JavaScript logic and data to populate and manage the equipment modal experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de9584a14083339c353e97d534d747